### PR TITLE
20260422 #21 닉네임 중복 확인 및 닉네임 변경 api 구현

### DIFF
--- a/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/CheckNicknameRequest.java
+++ b/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/CheckNicknameRequest.java
@@ -1,0 +1,12 @@
+package com.elipair.spacestudyship.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CheckNicknameRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.")
+        String nickname
+) {}

--- a/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/CheckNicknameResponse.java
+++ b/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/CheckNicknameResponse.java
@@ -1,0 +1,5 @@
+package com.elipair.spacestudyship.auth.dto;
+
+public record CheckNicknameResponse(
+        boolean available
+) {}

--- a/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/UpdateNicknameRequest.java
+++ b/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/UpdateNicknameRequest.java
@@ -1,0 +1,12 @@
+package com.elipair.spacestudyship.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateNicknameRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.")
+        String nickname
+) {}

--- a/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/UpdateNicknameResponse.java
+++ b/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/UpdateNicknameResponse.java
@@ -1,0 +1,5 @@
+package com.elipair.spacestudyship.auth.dto;
+
+public record UpdateNicknameResponse(
+        String nickname
+) {}

--- a/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/service/AuthService.java
+++ b/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/service/AuthService.java
@@ -11,6 +11,7 @@ import com.elipair.spacestudyship.member.constant.SocialType;
 import com.elipair.spacestudyship.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -135,11 +136,23 @@ public class AuthService {
      */
     @Transactional
     public UpdateNicknameResponse updateNickname(Long memberId, UpdateNicknameRequest request) {
-        if (memberRepository.existsByNickname(request.nickname())) {
+        Member member = memberRepository.getByMemberId(memberId);
+        String newNickname = request.nickname();
+
+        if (member.getNickname().equals(newNickname)) {
+            return new UpdateNicknameResponse(member.getNickname());
+        }
+
+        if (memberRepository.existsByNickname(newNickname)) {
             throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
         }
-        Member member = memberRepository.getByMemberId(memberId);
-        member.updateNickname(request.nickname());
+
+        try {
+            member.updateNickname(newNickname);
+            memberRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
+        }
         return new UpdateNicknameResponse(member.getNickname());
     }
 

--- a/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/service/AuthService.java
+++ b/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/service/AuthService.java
@@ -121,4 +121,13 @@ public class AuthService {
                 .ifPresent(refreshTokenRepository::delete);
     }
 
+    /**
+     * 닉네임 중복 확인
+     */
+    @Transactional(readOnly = true)
+    public CheckNicknameResponse checkNickname(String nickname) {
+        boolean exists = memberRepository.existsByNickname(nickname);
+        return new CheckNicknameResponse(!exists);
+    }
+
 }

--- a/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/service/AuthService.java
+++ b/SS-Auth/src/main/java/com/elipair/spacestudyship/auth/service/AuthService.java
@@ -130,4 +130,17 @@ public class AuthService {
         return new CheckNicknameResponse(!exists);
     }
 
+    /**
+     * 닉네임 변경
+     */
+    @Transactional
+    public UpdateNicknameResponse updateNickname(Long memberId, UpdateNicknameRequest request) {
+        if (memberRepository.existsByNickname(request.nickname())) {
+            throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
+        }
+        Member member = memberRepository.getByMemberId(memberId);
+        member.updateNickname(request.nickname());
+        return new UpdateNicknameResponse(member.getNickname());
+    }
+
 }

--- a/SS-Auth/src/test/java/com/elipair/spacestudyship/auth/service/AuthServiceTest.java
+++ b/SS-Auth/src/test/java/com/elipair/spacestudyship/auth/service/AuthServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Map;
 
@@ -24,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -85,8 +87,8 @@ class AuthServiceTest {
                 .socialType(SocialType.GOOGLE)
                 .nickname("기존닉네임")
                 .build();
-        given(memberRepository.existsByNickname(newNickname)).willReturn(false);
         given(memberRepository.getByMemberId(memberId)).willReturn(member);
+        given(memberRepository.existsByNickname(newNickname)).willReturn(false);
 
         // when
         UpdateNicknameResponse response = authService.updateNickname(memberId, request);
@@ -94,6 +96,31 @@ class AuthServiceTest {
         // then
         assertThat(response.nickname()).isEqualTo(newNickname);
         assertThat(member.getNickname()).isEqualTo(newNickname);
+        verify(memberRepository).flush();
+    }
+
+    @Test
+    @DisplayName("updateNickname: 본인 현재 닉네임과 같으면 중복 검사 없이 그대로 통과")
+    void updateNickname_sameAsCurrent() {
+        // given
+        Long memberId = 1L;
+        String currentNickname = "우주탐험가";
+        UpdateNicknameRequest request = new UpdateNicknameRequest(currentNickname);
+        Member member = Member.builder()
+                .id(memberId)
+                .socialId("social-id")
+                .socialType(SocialType.GOOGLE)
+                .nickname(currentNickname)
+                .build();
+        given(memberRepository.getByMemberId(memberId)).willReturn(member);
+
+        // when
+        UpdateNicknameResponse response = authService.updateNickname(memberId, request);
+
+        // then
+        assertThat(response.nickname()).isEqualTo(currentNickname);
+        verify(memberRepository, never()).existsByNickname(any());
+        verify(memberRepository, never()).flush();
     }
 
     @Test
@@ -103,13 +130,44 @@ class AuthServiceTest {
         Long memberId = 1L;
         String newNickname = "우주탐험가";
         UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
+        Member member = Member.builder()
+                .id(memberId)
+                .socialId("social-id")
+                .socialType(SocialType.GOOGLE)
+                .nickname("기존닉네임")
+                .build();
+        given(memberRepository.getByMemberId(memberId)).willReturn(member);
         given(memberRepository.existsByNickname(newNickname)).willReturn(true);
 
         // when / then
         assertThatThrownBy(() -> authService.updateNickname(memberId, request))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATED_NICKNAME);
-        verify(memberRepository, never()).getByMemberId(any());
+        verify(memberRepository, never()).flush();
+    }
+
+    @Test
+    @DisplayName("updateNickname: flush 단계 race로 DataIntegrityViolation 발생 시 DUPLICATED_NICKNAME으로 변환")
+    void updateNickname_raceCondition() {
+        // given
+        Long memberId = 1L;
+        String newNickname = "우주탐험가";
+        UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
+        Member member = Member.builder()
+                .id(memberId)
+                .socialId("social-id")
+                .socialType(SocialType.GOOGLE)
+                .nickname("기존닉네임")
+                .build();
+        given(memberRepository.getByMemberId(memberId)).willReturn(member);
+        given(memberRepository.existsByNickname(newNickname)).willReturn(false);
+        willThrow(new DataIntegrityViolationException("uk_nickname"))
+                .given(memberRepository).flush();
+
+        // when / then
+        assertThatThrownBy(() -> authService.updateNickname(memberId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATED_NICKNAME);
     }
 
     @Test
@@ -119,12 +177,12 @@ class AuthServiceTest {
         Long memberId = 1L;
         String newNickname = "우주탐험가";
         UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
-        given(memberRepository.existsByNickname(newNickname)).willReturn(false);
         given(memberRepository.getByMemberId(memberId)).willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         // when / then
         assertThatThrownBy(() -> authService.updateNickname(memberId, request))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+        verify(memberRepository, never()).existsByNickname(any());
     }
 }

--- a/SS-Auth/src/test/java/com/elipair/spacestudyship/auth/service/AuthServiceTest.java
+++ b/SS-Auth/src/test/java/com/elipair/spacestudyship/auth/service/AuthServiceTest.java
@@ -1,10 +1,15 @@
 package com.elipair.spacestudyship.auth.service;
 
 import com.elipair.spacestudyship.auth.dto.CheckNicknameResponse;
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameRequest;
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameResponse;
 import com.elipair.spacestudyship.auth.jwt.JwtTokenProvider;
 import com.elipair.spacestudyship.auth.repository.RefreshTokenRepository;
 import com.elipair.spacestudyship.auth.social.SocialLoginStrategy;
+import com.elipair.spacestudyship.common.exception.CustomException;
+import com.elipair.spacestudyship.common.exception.ErrorCode;
 import com.elipair.spacestudyship.member.constant.SocialType;
+import com.elipair.spacestudyship.member.entity.Member;
 import com.elipair.spacestudyship.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +21,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -61,5 +70,61 @@ class AuthServiceTest {
 
         // then
         assertThat(response.available()).isFalse();
+    }
+
+    @Test
+    @DisplayName("updateNickname: 중복 없으면 닉네임 변경 성공")
+    void updateNickname_success() {
+        // given
+        Long memberId = 1L;
+        String newNickname = "우주탐험가";
+        UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
+        Member member = Member.builder()
+                .id(memberId)
+                .socialId("social-id")
+                .socialType(SocialType.GOOGLE)
+                .nickname("기존닉네임")
+                .build();
+        given(memberRepository.existsByNickname(newNickname)).willReturn(false);
+        given(memberRepository.getByMemberId(memberId)).willReturn(member);
+
+        // when
+        UpdateNicknameResponse response = authService.updateNickname(memberId, request);
+
+        // then
+        assertThat(response.nickname()).isEqualTo(newNickname);
+        assertThat(member.getNickname()).isEqualTo(newNickname);
+    }
+
+    @Test
+    @DisplayName("updateNickname: 이미 사용 중인 닉네임이면 DUPLICATED_NICKNAME")
+    void updateNickname_duplicated() {
+        // given
+        Long memberId = 1L;
+        String newNickname = "우주탐험가";
+        UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
+        given(memberRepository.existsByNickname(newNickname)).willReturn(true);
+
+        // when / then
+        assertThatThrownBy(() -> authService.updateNickname(memberId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATED_NICKNAME);
+        verify(memberRepository, never()).getByMemberId(any());
+    }
+
+    @Test
+    @DisplayName("updateNickname: 회원이 없으면 MEMBER_NOT_FOUND")
+    void updateNickname_memberNotFound() {
+        // given
+        Long memberId = 1L;
+        String newNickname = "우주탐험가";
+        UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
+        given(memberRepository.existsByNickname(newNickname)).willReturn(false);
+        given(memberRepository.getByMemberId(memberId)).willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // when / then
+        assertThatThrownBy(() -> authService.updateNickname(memberId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
     }
 }

--- a/SS-Auth/src/test/java/com/elipair/spacestudyship/auth/service/AuthServiceTest.java
+++ b/SS-Auth/src/test/java/com/elipair/spacestudyship/auth/service/AuthServiceTest.java
@@ -1,0 +1,65 @@
+package com.elipair.spacestudyship.auth.service;
+
+import com.elipair.spacestudyship.auth.dto.CheckNicknameResponse;
+import com.elipair.spacestudyship.auth.jwt.JwtTokenProvider;
+import com.elipair.spacestudyship.auth.repository.RefreshTokenRepository;
+import com.elipair.spacestudyship.auth.social.SocialLoginStrategy;
+import com.elipair.spacestudyship.member.constant.SocialType;
+import com.elipair.spacestudyship.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+    @Mock
+    RandomNicknameGenerator randomNicknameGenerator;
+    @Mock
+    Map<SocialType, SocialLoginStrategy> socialLoginStrategies;
+
+    @InjectMocks
+    AuthService authService;
+
+    @Test
+    @DisplayName("checkNickname: DB에 닉네임이 없으면 available=true")
+    void checkNickname_available() {
+        // given
+        String nickname = "우주탐험가";
+        given(memberRepository.existsByNickname(nickname)).willReturn(false);
+
+        // when
+        CheckNicknameResponse response = authService.checkNickname(nickname);
+
+        // then
+        assertThat(response.available()).isTrue();
+    }
+
+    @Test
+    @DisplayName("checkNickname: DB에 닉네임이 있으면 available=false")
+    void checkNickname_notAvailable() {
+        // given
+        String nickname = "우주탐험가";
+        given(memberRepository.existsByNickname(nickname)).willReturn(true);
+
+        // when
+        CheckNicknameResponse response = authService.checkNickname(nickname);
+
+        // then
+        assertThat(response.available()).isFalse();
+    }
+}

--- a/SS-Web/src/main/java/com/elipair/spacestudyship/config/WebConfig.java
+++ b/SS-Web/src/main/java/com/elipair/spacestudyship/config/WebConfig.java
@@ -24,6 +24,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludePathPatterns(
                         "/api/auth/login",
                         "/api/auth/reissue",
+                        "/api/auth/logout",
                         "/actuator/health"
                 );
     }

--- a/SS-Web/src/main/java/com/elipair/spacestudyship/config/WebConfig.java
+++ b/SS-Web/src/main/java/com/elipair/spacestudyship/config/WebConfig.java
@@ -22,7 +22,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(authInterceptor)
                 .addPathPatterns("/api/**")
                 .excludePathPatterns(
-                        "/api/auth/**",  // AuthController - 인증 불필요 (login, reissue, logout)
+                        "/api/auth/login",
+                        "/api/auth/reissue",
                         "/actuator/health"
                 );
     }

--- a/SS-Web/src/main/java/com/elipair/spacestudyship/controller/auth/AuthController.java
+++ b/SS-Web/src/main/java/com/elipair/spacestudyship/controller/auth/AuthController.java
@@ -3,6 +3,8 @@ package com.elipair.spacestudyship.controller.auth;
 import com.elipair.spacestudyship.auth.dto.CheckNicknameRequest;
 import com.elipair.spacestudyship.auth.dto.CheckNicknameResponse;
 import com.elipair.spacestudyship.auth.dto.LoginRequest;
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameRequest;
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameResponse;
 import com.elipair.spacestudyship.auth.dto.LoginResponse;
 import com.elipair.spacestudyship.auth.dto.LogoutRequest;
 import com.elipair.spacestudyship.auth.dto.ReissueRequest;
@@ -55,5 +57,13 @@ public class AuthController {
             @AuthMember LoginMember loginMember,
             @Valid @ModelAttribute CheckNicknameRequest request) {
         return ResponseEntity.ok(authService.checkNickname(request.nickname()));
+    }
+
+    @Operation(summary = "닉네임 변경")
+    @PatchMapping("/nickname")
+    public ResponseEntity<UpdateNicknameResponse> updateNickname(
+            @AuthMember LoginMember loginMember,
+            @RequestBody @Valid UpdateNicknameRequest request) {
+        return ResponseEntity.ok(authService.updateNickname(loginMember.memberId(), request));
     }
 }

--- a/SS-Web/src/main/java/com/elipair/spacestudyship/controller/auth/AuthController.java
+++ b/SS-Web/src/main/java/com/elipair/spacestudyship/controller/auth/AuthController.java
@@ -1,10 +1,14 @@
 package com.elipair.spacestudyship.controller.auth;
 
+import com.elipair.spacestudyship.auth.dto.CheckNicknameRequest;
+import com.elipair.spacestudyship.auth.dto.CheckNicknameResponse;
 import com.elipair.spacestudyship.auth.dto.LoginRequest;
 import com.elipair.spacestudyship.auth.dto.LoginResponse;
 import com.elipair.spacestudyship.auth.dto.LogoutRequest;
 import com.elipair.spacestudyship.auth.dto.ReissueRequest;
 import com.elipair.spacestudyship.auth.dto.ReissueResponse;
+import com.elipair.spacestudyship.auth.interceptor.AuthMember;
+import com.elipair.spacestudyship.auth.interceptor.LoginMember;
 import com.elipair.spacestudyship.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,5 +47,13 @@ public class AuthController {
     public ResponseEntity<Void> logout(@RequestBody @Valid LogoutRequest request) {
         authService.logout(request.refreshToken());
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "닉네임 중복 확인")
+    @GetMapping("/check-nickname")
+    public ResponseEntity<CheckNicknameResponse> checkNickname(
+            @AuthMember LoginMember loginMember,
+            @Valid @ModelAttribute CheckNicknameRequest request) {
+        return ResponseEntity.ok(authService.checkNickname(request.nickname()));
     }
 }

--- a/SS-Web/src/test/java/com/elipair/spacestudyship/controller/auth/AuthControllerTest.java
+++ b/SS-Web/src/test/java/com/elipair/spacestudyship/controller/auth/AuthControllerTest.java
@@ -1,21 +1,28 @@
 package com.elipair.spacestudyship.controller.auth;
 
 import com.elipair.spacestudyship.auth.dto.CheckNicknameResponse;
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameRequest;
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameResponse;
 import com.elipair.spacestudyship.auth.interceptor.LoginMember;
 import com.elipair.spacestudyship.auth.interceptor.LoginMemberArgumentResolver;
 import com.elipair.spacestudyship.auth.service.AuthService;
+import com.elipair.spacestudyship.common.exception.CustomException;
+import com.elipair.spacestudyship.common.exception.ErrorCode;
 import com.elipair.spacestudyship.common.exception.GlobalExceptionHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -26,6 +33,8 @@ class AuthControllerTest {
     AuthService authService;
 
     MockMvc mockMvc;
+
+    ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     void setUp() {
@@ -92,6 +101,74 @@ class AuthControllerTest {
     void checkNickname_unauthenticated() throws Exception {
         mockMvc.perform(get("/api/auth/check-nickname")
                         .param("nickname", "우주탐험가"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ========== PATCH /api/auth/nickname ==========
+
+    @Test
+    @DisplayName("updateNickname: 정상 요청이면 200과 바뀐 nickname 반환")
+    void updateNickname_success() throws Exception {
+        // given
+        UpdateNicknameRequest body = new UpdateNicknameRequest("우주탐험가");
+        given(authService.updateNickname(1L, body))
+                .willReturn(new UpdateNicknameResponse("우주탐험가"));
+
+        // when / then
+        mockMvc.perform(patch("/api/auth/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body))
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nickname").value("우주탐험가"));
+    }
+
+    @Test
+    @DisplayName("updateNickname: 1자 닉네임이면 400")
+    void updateNickname_tooShort() throws Exception {
+        UpdateNicknameRequest body = new UpdateNicknameRequest("가");
+
+        mockMvc.perform(patch("/api/auth/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body))
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("updateNickname: 특수문자 포함이면 400")
+    void updateNickname_invalidCharacter() throws Exception {
+        UpdateNicknameRequest body = new UpdateNicknameRequest("우주!탐험");
+
+        mockMvc.perform(patch("/api/auth/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body))
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("updateNickname: 중복 닉네임이면 409")
+    void updateNickname_duplicated() throws Exception {
+        UpdateNicknameRequest body = new UpdateNicknameRequest("우주탐험가");
+        given(authService.updateNickname(1L, body))
+                .willThrow(new CustomException(ErrorCode.DUPLICATED_NICKNAME));
+
+        mockMvc.perform(patch("/api/auth/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body))
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("updateNickname: 인증 정보가 없으면 401")
+    void updateNickname_unauthenticated() throws Exception {
+        UpdateNicknameRequest body = new UpdateNicknameRequest("우주탐험가");
+
+        mockMvc.perform(patch("/api/auth/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/SS-Web/src/test/java/com/elipair/spacestudyship/controller/auth/AuthControllerTest.java
+++ b/SS-Web/src/test/java/com/elipair/spacestudyship/controller/auth/AuthControllerTest.java
@@ -1,0 +1,97 @@
+package com.elipair.spacestudyship.controller.auth;
+
+import com.elipair.spacestudyship.auth.dto.CheckNicknameResponse;
+import com.elipair.spacestudyship.auth.interceptor.LoginMember;
+import com.elipair.spacestudyship.auth.interceptor.LoginMemberArgumentResolver;
+import com.elipair.spacestudyship.auth.service.AuthService;
+import com.elipair.spacestudyship.common.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @Mock
+    AuthService authService;
+
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new AuthController(authService))
+                .setCustomArgumentResolvers(new LoginMemberArgumentResolver())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    // ========== GET /api/auth/check-nickname ==========
+
+    @Test
+    @DisplayName("checkNickname: 정상 요청이면 200과 available 반환")
+    void checkNickname_success() throws Exception {
+        // given
+        given(authService.checkNickname("우주탐험가"))
+                .willReturn(new CheckNicknameResponse(true));
+
+        // when / then
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .param("nickname", "우주탐험가")
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(true));
+    }
+
+    @Test
+    @DisplayName("checkNickname: nickname 파라미터가 없으면 400")
+    void checkNickname_missingParam() throws Exception {
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("checkNickname: 1자(길이 미달)이면 400")
+    void checkNickname_tooShort() throws Exception {
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .param("nickname", "가")
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("checkNickname: 11자(길이 초과)이면 400")
+    void checkNickname_tooLong() throws Exception {
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .param("nickname", "일이삼사오육칠팔구십일")
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("checkNickname: 특수문자가 포함되면 400")
+    void checkNickname_invalidCharacter() throws Exception {
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .param("nickname", "우주!탐험")
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("checkNickname: 인증 정보가 없으면 401")
+    void checkNickname_unauthenticated() throws Exception {
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .param("nickname", "우주탐험가"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/docs/superpowers/plans/2026-04-24-nickname-api.md
+++ b/docs/superpowers/plans/2026-04-24-nickname-api.md
@@ -1,0 +1,724 @@
+# 닉네임 중복 확인 및 닉네임 변경 API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `GET /api/auth/check-nickname`, `PATCH /api/auth/nickname` 두 개의 엔드포인트를 TDD로 구현하고 `/api/auth` 화이트리스트를 공개 API(`login`, `reissue`)만 남기도록 정리한다.
+
+**Architecture:** Controller(SS-Web) → AuthService(SS-Auth) → MemberRepository(SS-Member) 계층. 입력 검증은 Bean Validation이 붙은 record DTO로 처리하고, 미인증/중복/형식 오류는 `CustomException`/`GlobalExceptionHandler`가 담당. 인증은 기존 `AuthInterceptor` + `LoginMemberArgumentResolver` 재사용.
+
+**Tech Stack:** Java 21, Spring Boot 4.0.2, Spring Security, Spring Data JPA, Bean Validation(Jakarta), JUnit 5, Mockito, MockMvc(standalone).
+
+**Related spec:** [`docs/superpowers/specs/2026-04-24-nickname-api-design.md`](../specs/2026-04-24-nickname-api-design.md)
+
+---
+
+## File Plan
+
+| 파일 | 구분 | 책임 |
+|------|------|------|
+| `SS-Web/.../config/WebConfig.java` | 수정 | `AuthInterceptor` 예외 경로를 `login`/`reissue`/`actuator/health`로 축소 |
+| `SS-Auth/.../auth/dto/CheckNicknameRequest.java` | 신규 | `@ModelAttribute`로 바인딩될 닉네임 쿼리 DTO (검증 포함) |
+| `SS-Auth/.../auth/dto/CheckNicknameResponse.java` | 신규 | `{available: boolean}` 응답 record |
+| `SS-Auth/.../auth/dto/UpdateNicknameRequest.java` | 신규 | PATCH 본문 DTO (검증 포함) |
+| `SS-Auth/.../auth/dto/UpdateNicknameResponse.java` | 신규 | `{nickname: string}` 응답 record |
+| `SS-Auth/.../auth/service/AuthService.java` | 수정 | `checkNickname`, `updateNickname` 메서드 추가 |
+| `SS-Web/.../controller/auth/AuthController.java` | 수정 | GET/PATCH 엔드포인트 2개 추가 |
+| `SS-Auth/src/test/.../auth/service/AuthServiceTest.java` | 신규 | Service 단위 테스트 |
+| `SS-Web/src/test/.../controller/auth/AuthControllerTest.java` | 신규 | Controller 슬라이스 테스트 (MockMvc standalone) |
+
+---
+
+## Task 1: Interceptor 예외 경로 축소
+
+**Why first**: 신규 API의 인증 동작이 이 설정에 의존. 먼저 고쳐두고 빌드를 깨지 않게 유지.
+
+**아키텍처 메모**: Spring Security는 `SecurityUrls.AUTH_WHITELIST`에 `/api/auth/**`를 통째로 permit해 두고 있으며, 실제 JWT 검증은 `AuthInterceptor`가 담당한다. 따라서 `SecurityUrls`는 **변경하지 않고**, `WebConfig`의 인터셉터 `excludePathPatterns`만 축소한다. (만약 `SecurityUrls`에서 `/api/auth/**`를 빼면 Spring Security 필터 체인에 JWT 처리 필터가 없어 정상 요청도 401이 됨 — 이는 별도 이슈로 다룬다.)
+
+**Files:**
+- Modify: `SS-Web/src/main/java/com/elipair/spacestudyship/config/WebConfig.java`
+
+- [ ] **Step 1: `WebConfig.addInterceptors` 예외 경로 교체**
+
+`SS-Web/src/main/java/com/elipair/spacestudyship/config/WebConfig.java`의 `addInterceptors` 메서드를 다음처럼 변경:
+
+```java
+@Override
+public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(authInterceptor)
+            .addPathPatterns("/api/**")
+            .excludePathPatterns(
+                    "/api/auth/login",
+                    "/api/auth/reissue",
+                    "/actuator/health"
+            );
+}
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+Run: `./gradlew build -x test`
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add SS-Web/src/main/java/com/elipair/spacestudyship/config/WebConfig.java
+git commit -m "닉네임 중복 확인 및 닉네임 변경 API 구현 : refactor : AuthInterceptor 예외 경로를 공개 API로 한정 https://github.com/SpaceStudyShip/SpaceStudyShip-BE/issues/21"
+```
+
+---
+
+## Task 2: DTO 4종 작성
+
+**Why**: Controller/Service 시그니처를 먼저 확정해야 테스트를 TDD로 쓸 수 있음.
+
+**Files:**
+- Create: `SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/CheckNicknameRequest.java`
+- Create: `SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/CheckNicknameResponse.java`
+- Create: `SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/UpdateNicknameRequest.java`
+- Create: `SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/UpdateNicknameResponse.java`
+
+- [ ] **Step 1: `CheckNicknameRequest.java` 생성**
+
+```java
+package com.elipair.spacestudyship.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CheckNicknameRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.")
+        String nickname
+) {}
+```
+
+- [ ] **Step 2: `CheckNicknameResponse.java` 생성**
+
+```java
+package com.elipair.spacestudyship.auth.dto;
+
+public record CheckNicknameResponse(
+        boolean available
+) {}
+```
+
+- [ ] **Step 3: `UpdateNicknameRequest.java` 생성**
+
+```java
+package com.elipair.spacestudyship.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateNicknameRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.")
+        String nickname
+) {}
+```
+
+- [ ] **Step 4: `UpdateNicknameResponse.java` 생성**
+
+```java
+package com.elipair.spacestudyship.auth.dto;
+
+public record UpdateNicknameResponse(
+        String nickname
+) {}
+```
+
+- [ ] **Step 5: 빌드 검증**
+
+Run: `./gradlew :SS-Auth:compileJava`
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add SS-Auth/src/main/java/com/elipair/spacestudyship/auth/dto/
+git commit -m "닉네임 중복 확인 및 닉네임 변경 API 구현 : feat : 닉네임 요청/응답 DTO 추가 https://github.com/SpaceStudyShip/SpaceStudyShip-BE/issues/21"
+```
+
+---
+
+## Task 3: `AuthService.checkNickname` 구현 (TDD)
+
+**Files:**
+- Create: `SS-Auth/src/test/java/com/elipair/spacestudyship/auth/service/AuthServiceTest.java`
+- Modify: `SS-Auth/src/main/java/com/elipair/spacestudyship/auth/service/AuthService.java` (메서드 추가)
+
+- [ ] **Step 1: 실패 테스트 작성 (`AuthServiceTest.java` 신규)**
+
+```java
+package com.elipair.spacestudyship.auth.service;
+
+import com.elipair.spacestudyship.auth.dto.CheckNicknameResponse;
+import com.elipair.spacestudyship.auth.jwt.JwtTokenProvider;
+import com.elipair.spacestudyship.auth.repository.RefreshTokenRepository;
+import com.elipair.spacestudyship.auth.social.SocialLoginStrategy;
+import com.elipair.spacestudyship.member.constant.SocialType;
+import com.elipair.spacestudyship.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+    @Mock
+    RandomNicknameGenerator randomNicknameGenerator;
+    @Mock
+    Map<SocialType, SocialLoginStrategy> socialLoginStrategies;
+
+    @InjectMocks
+    AuthService authService;
+
+    @Test
+    @DisplayName("checkNickname: DB에 닉네임이 없으면 available=true")
+    void checkNickname_available() {
+        // given
+        String nickname = "우주탐험가";
+        given(memberRepository.existsByNickname(nickname)).willReturn(false);
+
+        // when
+        CheckNicknameResponse response = authService.checkNickname(nickname);
+
+        // then
+        assertThat(response.available()).isTrue();
+    }
+
+    @Test
+    @DisplayName("checkNickname: DB에 닉네임이 있으면 available=false")
+    void checkNickname_notAvailable() {
+        // given
+        String nickname = "우주탐험가";
+        given(memberRepository.existsByNickname(nickname)).willReturn(true);
+
+        // when
+        CheckNicknameResponse response = authService.checkNickname(nickname);
+
+        // then
+        assertThat(response.available()).isFalse();
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인**
+
+Run: `./gradlew :SS-Auth:test --tests com.elipair.spacestudyship.auth.service.AuthServiceTest`
+Expected: 컴파일 실패 (`authService.checkNickname` 메서드 없음)
+
+- [ ] **Step 3: `AuthService`에 `checkNickname` 구현**
+
+`AuthService.java`의 클래스 본문에 다음 메서드 추가 (기존 `logout` 뒤, 클래스 닫는 중괄호 전):
+
+```java
+/**
+ * 닉네임 중복 확인
+ */
+@Transactional(readOnly = true)
+public CheckNicknameResponse checkNickname(String nickname) {
+    boolean exists = memberRepository.existsByNickname(nickname);
+    return new CheckNicknameResponse(!exists);
+}
+```
+
+파일 상단 import 구문에 필요 시 추가:
+```java
+import com.elipair.spacestudyship.auth.dto.CheckNicknameResponse;
+```
+(이미 `com.elipair.spacestudyship.auth.dto.*` 와일드카드 import가 있으면 생략)
+
+- [ ] **Step 4: 테스트 실행 → 통과 확인**
+
+Run: `./gradlew :SS-Auth:test --tests com.elipair.spacestudyship.auth.service.AuthServiceTest`
+Expected: 2 tests passed
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add SS-Auth/src/test/java/com/elipair/spacestudyship/auth/service/AuthServiceTest.java \
+        SS-Auth/src/main/java/com/elipair/spacestudyship/auth/service/AuthService.java
+git commit -m "닉네임 중복 확인 및 닉네임 변경 API 구현 : feat : AuthService.checkNickname 추가 https://github.com/SpaceStudyShip/SpaceStudyShip-BE/issues/21"
+```
+
+---
+
+## Task 4: `AuthService.updateNickname` 구현 (TDD)
+
+**Files:**
+- Modify: `SS-Auth/src/test/java/com/elipair/spacestudyship/auth/service/AuthServiceTest.java` (테스트 추가)
+- Modify: `SS-Auth/src/main/java/com/elipair/spacestudyship/auth/service/AuthService.java` (메서드 추가)
+
+- [ ] **Step 1: 실패 테스트 추가**
+
+`AuthServiceTest.java` 상단 import에 추가:
+
+```java
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameRequest;
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameResponse;
+import com.elipair.spacestudyship.common.exception.CustomException;
+import com.elipair.spacestudyship.common.exception.ErrorCode;
+import com.elipair.spacestudyship.member.entity.Member;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+```
+
+**참고**: `MemberRepository.getByMemberId`는 `default` 인터페이스 메서드다. Mockito는 default method body를 실행하지 않고 바로 mock으로 감싸기 때문에, `findById`가 아닌 `getByMemberId`를 직접 stub해야 한다.
+
+클래스 본문 말미(닫는 중괄호 전)에 다음 테스트 3개 추가:
+
+```java
+@Test
+@DisplayName("updateNickname: 중복 없으면 닉네임 변경 성공")
+void updateNickname_success() {
+    // given
+    Long memberId = 1L;
+    String newNickname = "우주탐험가";
+    UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
+    Member member = Member.builder()
+            .id(memberId)
+            .socialId("social-id")
+            .socialType(SocialType.GOOGLE)
+            .nickname("기존닉네임")
+            .build();
+    given(memberRepository.existsByNickname(newNickname)).willReturn(false);
+    given(memberRepository.getByMemberId(memberId)).willReturn(member);
+
+    // when
+    UpdateNicknameResponse response = authService.updateNickname(memberId, request);
+
+    // then
+    assertThat(response.nickname()).isEqualTo(newNickname);
+    assertThat(member.getNickname()).isEqualTo(newNickname);
+}
+
+@Test
+@DisplayName("updateNickname: 이미 사용 중인 닉네임이면 DUPLICATED_NICKNAME")
+void updateNickname_duplicated() {
+    // given
+    Long memberId = 1L;
+    String newNickname = "우주탐험가";
+    UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
+    given(memberRepository.existsByNickname(newNickname)).willReturn(true);
+
+    // when / then
+    assertThatThrownBy(() -> authService.updateNickname(memberId, request))
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATED_NICKNAME);
+    verify(memberRepository, never()).getByMemberId(any());
+}
+
+@Test
+@DisplayName("updateNickname: 회원이 없으면 MEMBER_NOT_FOUND")
+void updateNickname_memberNotFound() {
+    // given
+    Long memberId = 1L;
+    String newNickname = "우주탐험가";
+    UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
+    given(memberRepository.existsByNickname(newNickname)).willReturn(false);
+    given(memberRepository.getByMemberId(memberId))
+            .willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+    // when / then
+    assertThatThrownBy(() -> authService.updateNickname(memberId, request))
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode").isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+}
+```
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인**
+
+Run: `./gradlew :SS-Auth:test --tests com.elipair.spacestudyship.auth.service.AuthServiceTest`
+Expected: 컴파일 실패 (`authService.updateNickname` 메서드 없음)
+
+- [ ] **Step 3: `AuthService`에 `updateNickname` 구현**
+
+`AuthService.java`의 `checkNickname` 바로 뒤에 다음 메서드 추가:
+
+```java
+/**
+ * 닉네임 변경
+ */
+@Transactional
+public UpdateNicknameResponse updateNickname(Long memberId, UpdateNicknameRequest request) {
+    if (memberRepository.existsByNickname(request.nickname())) {
+        throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
+    }
+    Member member = memberRepository.getByMemberId(memberId);
+    member.updateNickname(request.nickname());
+    return new UpdateNicknameResponse(member.getNickname());
+}
+```
+
+필요한 import 추가 (와일드카드로 이미 커버되면 생략):
+```java
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameRequest;
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameResponse;
+```
+
+- [ ] **Step 4: 테스트 실행 → 전체 통과 확인**
+
+Run: `./gradlew :SS-Auth:test --tests com.elipair.spacestudyship.auth.service.AuthServiceTest`
+Expected: 5 tests passed
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add SS-Auth/src/test/java/com/elipair/spacestudyship/auth/service/AuthServiceTest.java \
+        SS-Auth/src/main/java/com/elipair/spacestudyship/auth/service/AuthService.java
+git commit -m "닉네임 중복 확인 및 닉네임 변경 API 구현 : feat : AuthService.updateNickname 추가 https://github.com/SpaceStudyShip/SpaceStudyShip-BE/issues/21"
+```
+
+---
+
+## Task 5: `AuthController.checkNickname` 엔드포인트 구현 (TDD - 슬라이스)
+
+**Test 전략 메모:** `@WebMvcTest`는 `application.yml`의 `prod` 프로파일과 Firebase/Flyway 등 외부 의존성 때문에 컨텍스트 로드가 까다로워질 수 있음. 대신 `MockMvcBuilders.standaloneSetup`으로 ArgumentResolver와 ControllerAdvice만 직접 주입해 가볍게 구성한다. 이 방식은 `@RequestBody @Valid`, `@ModelAttribute @Valid` 검증이 모두 정상 동작함.
+
+**Files:**
+- Create: `SS-Web/src/test/java/com/elipair/spacestudyship/controller/auth/AuthControllerTest.java`
+- Modify: `SS-Web/src/main/java/com/elipair/spacestudyship/controller/auth/AuthController.java` (GET 엔드포인트 추가)
+
+- [ ] **Step 1: 실패 테스트 작성 (`AuthControllerTest.java` 신규)**
+
+```java
+package com.elipair.spacestudyship.controller.auth;
+
+import com.elipair.spacestudyship.auth.dto.CheckNicknameResponse;
+import com.elipair.spacestudyship.auth.interceptor.LoginMember;
+import com.elipair.spacestudyship.auth.interceptor.LoginMemberArgumentResolver;
+import com.elipair.spacestudyship.auth.service.AuthService;
+import com.elipair.spacestudyship.common.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @Mock
+    AuthService authService;
+
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new AuthController(authService))
+                .setCustomArgumentResolvers(new LoginMemberArgumentResolver())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    // ========== GET /api/auth/check-nickname ==========
+
+    @Test
+    @DisplayName("checkNickname: 정상 요청이면 200과 available 반환")
+    void checkNickname_success() throws Exception {
+        // given
+        given(authService.checkNickname("우주탐험가"))
+                .willReturn(new CheckNicknameResponse(true));
+
+        // when / then
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .param("nickname", "우주탐험가")
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(true));
+    }
+
+    @Test
+    @DisplayName("checkNickname: nickname 파라미터가 없으면 400")
+    void checkNickname_missingParam() throws Exception {
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("checkNickname: 1자(길이 미달)이면 400")
+    void checkNickname_tooShort() throws Exception {
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .param("nickname", "가")
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("checkNickname: 11자(길이 초과)이면 400")
+    void checkNickname_tooLong() throws Exception {
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .param("nickname", "일이삼사오육칠팔구십일")
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("checkNickname: 특수문자가 포함되면 400")
+    void checkNickname_invalidCharacter() throws Exception {
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .param("nickname", "우주!탐험")
+                        .requestAttr("loginMember", new LoginMember(1L)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("checkNickname: 인증 정보가 없으면 401")
+    void checkNickname_unauthenticated() throws Exception {
+        mockMvc.perform(get("/api/auth/check-nickname")
+                        .param("nickname", "우주탐험가"))
+                .andExpect(status().isUnauthorized());
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인**
+
+Run: `./gradlew :SS-Web:test --tests com.elipair.spacestudyship.controller.auth.AuthControllerTest`
+Expected: 컴파일 실패 또는 404 (GET 엔드포인트 없음)
+
+- [ ] **Step 3: `AuthController`에 GET 엔드포인트 추가**
+
+import 추가:
+```java
+import com.elipair.spacestudyship.auth.dto.CheckNicknameRequest;
+import com.elipair.spacestudyship.auth.dto.CheckNicknameResponse;
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameRequest;
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameResponse;
+import com.elipair.spacestudyship.auth.interceptor.AuthMember;
+import com.elipair.spacestudyship.auth.interceptor.LoginMember;
+import org.springframework.web.bind.annotation.ModelAttribute;
+```
+
+클래스 본문(기존 `logout` 아래)에 다음 메서드 추가:
+
+```java
+@Operation(summary = "닉네임 중복 확인")
+@GetMapping("/check-nickname")
+public ResponseEntity<CheckNicknameResponse> checkNickname(
+        @AuthMember LoginMember loginMember,
+        @Valid @ModelAttribute CheckNicknameRequest request) {
+    return ResponseEntity.ok(authService.checkNickname(request.nickname()));
+}
+```
+
+- [ ] **Step 4: 테스트 실행 → 전체 통과 확인**
+
+Run: `./gradlew :SS-Web:test --tests com.elipair.spacestudyship.controller.auth.AuthControllerTest`
+Expected: 6 tests passed
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add SS-Web/src/test/java/com/elipair/spacestudyship/controller/auth/AuthControllerTest.java \
+        SS-Web/src/main/java/com/elipair/spacestudyship/controller/auth/AuthController.java
+git commit -m "닉네임 중복 확인 및 닉네임 변경 API 구현 : feat : GET /api/auth/check-nickname 엔드포인트 추가 https://github.com/SpaceStudyShip/SpaceStudyShip-BE/issues/21"
+```
+
+---
+
+## Task 6: `AuthController.updateNickname` 엔드포인트 구현 (TDD - 슬라이스)
+
+**Files:**
+- Modify: `SS-Web/src/test/java/com/elipair/spacestudyship/controller/auth/AuthControllerTest.java` (테스트 추가)
+- Modify: `SS-Web/src/main/java/com/elipair/spacestudyship/controller/auth/AuthController.java` (PATCH 엔드포인트 추가)
+
+- [ ] **Step 1: 실패 테스트 추가**
+
+`AuthControllerTest.java` 상단 import에 추가:
+
+```java
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameRequest;
+import com.elipair.spacestudyship.auth.dto.UpdateNicknameResponse;
+import com.elipair.spacestudyship.common.exception.CustomException;
+import com.elipair.spacestudyship.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+```
+
+클래스 본문 필드 영역에 ObjectMapper 추가:
+
+```java
+ObjectMapper objectMapper = new ObjectMapper();
+```
+
+클래스 본문 말미(닫는 중괄호 전)에 다음 테스트 5개 추가:
+
+```java
+// ========== PATCH /api/auth/nickname ==========
+
+@Test
+@DisplayName("updateNickname: 정상 요청이면 200과 바뀐 nickname 반환")
+void updateNickname_success() throws Exception {
+    // given
+    UpdateNicknameRequest body = new UpdateNicknameRequest("우주탐험가");
+    given(authService.updateNickname(1L, body))
+            .willReturn(new UpdateNicknameResponse("우주탐험가"));
+
+    // when / then
+    mockMvc.perform(patch("/api/auth/nickname")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(body))
+                    .requestAttr("loginMember", new LoginMember(1L)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.nickname").value("우주탐험가"));
+}
+
+@Test
+@DisplayName("updateNickname: 1자 닉네임이면 400")
+void updateNickname_tooShort() throws Exception {
+    UpdateNicknameRequest body = new UpdateNicknameRequest("가");
+
+    mockMvc.perform(patch("/api/auth/nickname")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(body))
+                    .requestAttr("loginMember", new LoginMember(1L)))
+            .andExpect(status().isBadRequest());
+}
+
+@Test
+@DisplayName("updateNickname: 특수문자 포함이면 400")
+void updateNickname_invalidCharacter() throws Exception {
+    UpdateNicknameRequest body = new UpdateNicknameRequest("우주!탐험");
+
+    mockMvc.perform(patch("/api/auth/nickname")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(body))
+                    .requestAttr("loginMember", new LoginMember(1L)))
+            .andExpect(status().isBadRequest());
+}
+
+@Test
+@DisplayName("updateNickname: 중복 닉네임이면 409")
+void updateNickname_duplicated() throws Exception {
+    UpdateNicknameRequest body = new UpdateNicknameRequest("우주탐험가");
+    given(authService.updateNickname(1L, body))
+            .willThrow(new CustomException(ErrorCode.DUPLICATED_NICKNAME));
+
+    mockMvc.perform(patch("/api/auth/nickname")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(body))
+                    .requestAttr("loginMember", new LoginMember(1L)))
+            .andExpect(status().isConflict());
+}
+
+@Test
+@DisplayName("updateNickname: 인증 정보가 없으면 401")
+void updateNickname_unauthenticated() throws Exception {
+    UpdateNicknameRequest body = new UpdateNicknameRequest("우주탐험가");
+
+    mockMvc.perform(patch("/api/auth/nickname")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isUnauthorized());
+}
+```
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인**
+
+Run: `./gradlew :SS-Web:test --tests com.elipair.spacestudyship.controller.auth.AuthControllerTest`
+Expected: 404 또는 405 (PATCH 엔드포인트 없음)
+
+- [ ] **Step 3: `AuthController`에 PATCH 엔드포인트 추가**
+
+클래스 본문(기존 GET checkNickname 아래)에 다음 메서드 추가:
+
+```java
+@Operation(summary = "닉네임 변경")
+@PatchMapping("/nickname")
+public ResponseEntity<UpdateNicknameResponse> updateNickname(
+        @AuthMember LoginMember loginMember,
+        @RequestBody @Valid UpdateNicknameRequest request) {
+    return ResponseEntity.ok(authService.updateNickname(loginMember.memberId(), request));
+}
+```
+
+- [ ] **Step 4: 테스트 실행 → 전체 통과 확인**
+
+Run: `./gradlew :SS-Web:test --tests com.elipair.spacestudyship.controller.auth.AuthControllerTest`
+Expected: 11 tests passed (GET 6개 + PATCH 5개)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add SS-Web/src/test/java/com/elipair/spacestudyship/controller/auth/AuthControllerTest.java \
+        SS-Web/src/main/java/com/elipair/spacestudyship/controller/auth/AuthController.java
+git commit -m "닉네임 중복 확인 및 닉네임 변경 API 구현 : feat : PATCH /api/auth/nickname 엔드포인트 추가 https://github.com/SpaceStudyShip/SpaceStudyShip-BE/issues/21"
+```
+
+---
+
+## Task 7: 전체 빌드/테스트 검증
+
+- [ ] **Step 1: 전체 테스트 실행**
+
+Run: `./gradlew test`
+Expected: 전체 테스트 통과. 신규 테스트:
+- `AuthServiceTest` 5개
+- `AuthControllerTest` 11개
+
+기존 `SpaceStudyShipApplicationTests.contextLoads()`는 `prod` 프로파일이 활성이면 환경 변수/외부 의존성 때문에 실패할 수 있음 — 그 경우 **이전과 동일하게 실패**하는 것이지 이번 변경의 회귀가 아닌지 확인한다.
+
+- [ ] **Step 2: 전체 빌드 실행**
+
+Run: `./gradlew build`
+Expected: `BUILD SUCCESSFUL`
+(만약 기존에 깨져 있던 `SpaceStudyShipApplicationTests` 때문에 실패하면 해당 실패는 이번 변경과 무관함을 주석으로 남기고 태스크 완료 — 이 테스트는 이 이슈 범위가 아님)
+
+- [ ] **Step 3: 수동 검증 (선택)**
+
+브랜치를 `main`과 비교해 진단:
+
+```bash
+git diff main --stat
+```
+
+Expected: 의도한 파일들만 변경됨 (SecurityUrls, WebConfig, AuthController, AuthService, dto/, 테스트 2개).
+
+---
+
+## 수용 기준 체크리스트
+
+- [ ] `GET /api/auth/check-nickname?nickname=...`이 200 `{available}`를 반환
+- [ ] `PATCH /api/auth/nickname`이 200 `{nickname}`를 반환
+- [ ] 닉네임 형식 위반(길이/문자) 시 400
+- [ ] 중복 닉네임 변경 시도 시 409
+- [ ] 인증 없는 요청은 401
+- [ ] `/api/auth` 하위의 공개 경로는 `login`, `reissue`로 한정
+- [ ] `AuthServiceTest` 5개 모두 통과
+- [ ] `AuthControllerTest` 11개 모두 통과
+- [ ] 빌드 전체 녹색

--- a/docs/superpowers/specs/2026-04-24-nickname-api-design.md
+++ b/docs/superpowers/specs/2026-04-24-nickname-api-design.md
@@ -15,7 +15,7 @@
 ### 이번 PR 범위
 - `GET /api/auth/check-nickname` (신규)
 - `PATCH /api/auth/nickname` (신규)
-- `WebConfig.addInterceptors.excludePathPatterns` 축소 (공개 API인 `login`/`reissue`만 제외)
+- `WebConfig.addInterceptors.excludePathPatterns` 축소 (공개 API인 `login`/`reissue`/`logout`만 제외)
 - Service / Controller 테스트 코드 추가
 - `ErrorCode`에 필요 시 신규 코드 추가 (현재는 기존 `INVALID_INPUT_VALUE`, `DUPLICATED_NICKNAME` 활용)
 
@@ -30,7 +30,7 @@
 
 ### 2-1. 닉네임 중복 확인
 
-```
+```http
 GET /api/auth/check-nickname?nickname={nickname}
 Authorization: Bearer {accessToken}
 ```
@@ -47,7 +47,7 @@ Authorization: Bearer {accessToken}
 
 ### 2-2. 닉네임 변경
 
-```
+```http
 PATCH /api/auth/nickname
 Authorization: Bearer {accessToken}
 Content-Type: application/json
@@ -65,7 +65,11 @@ Content-Type: application/json
 | 미인증 | `401 UNAUTHENTICATED_REQUEST` |
 | 회원 없음 | `404 MEMBER_NOT_FOUND` (이론상, 유효 토큰+DB 삭제 동시 발생 시) |
 
-**동작**: 중복 체크 후 `Member.updateNickname()`로 갱신. JPA dirty checking으로 `UPDATE` 쿼리 발생. 토큰 재발급 없음.
+**동작**:
+1. 회원 조회 후, 요청 닉네임이 **본인 현재 닉네임과 동일**하면 중복 검사 없이 그대로 응답한다(NO-OP).
+2. 다른 회원이 사용 중이면 `409 DUPLICATED_NICKNAME`.
+3. 통과 시 `Member.updateNickname()`로 갱신, `flush()`까지 명시적으로 호출해 unique 제약 위반을 동기적으로 감지한다.
+4. JPA dirty checking으로 `UPDATE` 쿼리 발생. 토큰 재발급 없음.
 
 ### 2-3. 닉네임 형식 규칙
 
@@ -78,7 +82,7 @@ Content-Type: application/json
 
 ## 3. 파일 구조
 
-```
+```text
 SS-Web/
   src/main/java/com/elipair/spacestudyship/
     config/WebConfig.java               [수정] 인터셉터 예외 경로 축소
@@ -125,7 +129,7 @@ SS-Common/ (변경 없음)
 
 ### `GET /api/auth/check-nickname?nickname=...`
 
-```
+```text
 Request → AuthInterceptor (토큰 검증, request.loginMember 세팅)
        → LoginMemberArgumentResolver (LoginMember 주입)
        → AuthController.checkNickname(loginMember, @Valid nickname)
@@ -138,16 +142,19 @@ Request → AuthInterceptor (토큰 검증, request.loginMember 세팅)
 
 ### `PATCH /api/auth/nickname`
 
-```
+```text
 Request → AuthInterceptor → LoginMemberArgumentResolver
        → AuthController.updateNickname(loginMember, @Valid UpdateNicknameRequest)
            ↓ 형식 검증 실패 → 400
        → AuthService.updateNickname(loginMember.memberId(), request) [@Transactional]
-           1. existsByNickname(request.nickname())
-              → true면 throw CustomException(DUPLICATED_NICKNAME) [409]
-           2. getByMemberId(memberId)
+           1. getByMemberId(memberId)
               → 없으면 throw CustomException(MEMBER_NOT_FOUND) [404]
-           3. member.updateNickname(request.nickname())  // dirty checking
+           2. 본인 현재 닉네임과 동일하면 그대로 응답(중복 검사 없이 NO-OP)
+           3. existsByNickname(request.nickname())
+              → true면 throw CustomException(DUPLICATED_NICKNAME) [409]
+           4. member.updateNickname(request.nickname())  // dirty checking
+           5. memberRepository.flush()
+              → DataIntegrityViolationException 캐치 시 DUPLICATED_NICKNAME으로 변환 [409]
        → UpdateNicknameResponse(member.getNickname())
        → 200 OK
 ```
@@ -161,7 +168,7 @@ Request → AuthInterceptor → LoginMemberArgumentResolver
 ### 동시성 / 중복 방지
 
 - `PATCH` 요청에서 `existsByNickname` 체크 후 `update` 사이에 동일 닉네임으로 다른 트랜잭션이 `INSERT`/`UPDATE`할 경우 → **DB의 `nickname` unique 제약이 최종 방어선**
-- `@Transactional`로 원자성 확보. unique 제약 위반 시 `DataIntegrityViolationException`이 던져지며, 현재는 `Exception` 핸들러로 500 처리되지만 극히 드문 경합 상황이므로 이번 범위에서는 특별한 처리 없음 (별도 고도화 항목)
+- 서비스 메서드는 `member.updateNickname()` 직후 `memberRepository.flush()`로 즉시 DB에 반영하고, 발생하는 `DataIntegrityViolationException`을 `CustomException(DUPLICATED_NICKNAME)`으로 변환해 일관된 409 응답을 보장한다.
 
 ---
 
@@ -192,9 +199,12 @@ Request → AuthInterceptor → LoginMemberArgumentResolver
 .excludePathPatterns(
         "/api/auth/login",
         "/api/auth/reissue",
+        "/api/auth/logout",
         "/actuator/health"
 );
 ```
+
+> `logout`은 `AuthService.logout(String refreshToken)`이 **리프레시 토큰만** 사용하므로, 액세스 토큰이 만료된 상태에서도 호출 가능해야 한다. 그래서 인터셉터의 액세스 토큰 검증 대상에서 제외한다.
 
 `SecurityUrls.AUTH_WHITELIST`는 이번 범위에서 **변경하지 않는다**. Spring Security 계층 전면 재설계(JWT Security Filter 도입 등)는 별도 이슈에서 다룬다.
 
@@ -204,7 +214,7 @@ Request → AuthInterceptor → LoginMemberArgumentResolver
 |-----|----------|---------|
 | `POST /api/auth/login` | 공개 | 공개 (유지) |
 | `POST /api/auth/reissue` | 공개 | 공개 (유지) |
-| `POST /api/auth/logout` | 공개 (스펙 위반) | 인증 필요 (AuthInterceptor가 검증) |
+| `POST /api/auth/logout` | 공개 | 공개 (유지: 리프레시 토큰 기반이므로 액세스 토큰 검증 제외) |
 | `DELETE /api/auth/withdraw` | 미구현 | 미구현 (영향 없음) |
 | `GET /api/auth/check-nickname` | 신규 | 인증 필요 |
 | `PATCH /api/auth/nickname` | 신규 | 인증 필요 |
@@ -223,7 +233,9 @@ Request → AuthInterceptor → LoginMemberArgumentResolver
 
 **updateNickname**
 - 사용 가능한 닉네임 입력 → `Member.updateNickname` 호출, `UpdateNicknameResponse` 반환
-- 이미 존재하는 닉네임 입력 → `CustomException(DUPLICATED_NICKNAME)` throw, 업데이트 호출 안 됨
+- 본인 현재 닉네임과 동일한 값 입력 → 중복 검사 없이 그대로 응답 (NO-OP)
+- 이미 존재하는 닉네임 입력 → `CustomException(DUPLICATED_NICKNAME)` throw, `flush` 호출 안 됨
+- `flush` 단계에서 `DataIntegrityViolationException` 발생 → `CustomException(DUPLICATED_NICKNAME)`으로 변환
 - `memberId`로 조회 실패 → `CustomException(MEMBER_NOT_FOUND)` throw
 
 ### 6-2. `AuthControllerTest` (슬라이스 테스트, MockMvc)
@@ -242,9 +254,11 @@ Request → AuthInterceptor → LoginMemberArgumentResolver
 
 ### 6-3. Mocking 방침
 
-- Service 테스트: `@ExtendWith(MockitoExtension.class)` + `@Mock MemberRepository`
-- Controller 테스트: `@WebMvcTest(AuthController.class)` + `AuthService` 모킹, `LoginMemberArgumentResolver` 모킹 또는 request attribute에 `loginMember` 직접 세팅으로 인증 주입
-- 모킹 어노테이션은 Spring Boot 4.x 환경에 맞게 `@MockitoBean` 계열 사용 (Spring Framework 6.2+ 표준)
+이번 PR은 **standalone 방식**으로 통일한다.
+
+- Service 테스트: `@ExtendWith(MockitoExtension.class)` + `@Mock MemberRepository` + `@InjectMocks AuthService`
+- Controller 테스트: `@ExtendWith(MockitoExtension.class)` + `@Mock AuthService` + `MockMvcBuilders.standaloneSetup(...)` 로 컨트롤러 단독 구성. 인증은 `requestAttr("loginMember", new LoginMember(...))`로 주입하고, 직접 등록한 `LoginMemberArgumentResolver`가 이를 읽는다.
+- `@WebMvcTest`/`@MockitoBean` 기반 슬라이스는 이번 범위에서 사용하지 않는다 (Spring 컨텍스트 부팅 비용 절감 및 인터셉터 우회). 향후 통합 테스트 인프라 정비 이슈에서 표준화한다.
 
 ### 6-4. 통합 테스트
 

--- a/docs/superpowers/specs/2026-04-24-nickname-api-design.md
+++ b/docs/superpowers/specs/2026-04-24-nickname-api-design.md
@@ -1,0 +1,275 @@
+# 닉네임 중복 확인 및 닉네임 변경 API 설계
+
+- **Issue**: [#21 닉네임 중복 확인 및 닉네임 변경 API 구현](https://github.com/SpaceStudyShip/SpaceStudyShip-BE/issues/21)
+- **Branch**: `20260422_#21_닉네임_중복_확인_및_닉네임_변경_API_구현`
+- **Date**: 2026-04-24
+- **Status**: Approved (pending user review)
+
+---
+
+## 1. 목적과 범위
+
+### 목적
+회원이 자신의 닉네임을 변경할 수 있도록 2개의 API(중복 확인, 변경)를 제공한다.
+
+### 이번 PR 범위
+- `GET /api/auth/check-nickname` (신규)
+- `PATCH /api/auth/nickname` (신규)
+- `WebConfig.addInterceptors.excludePathPatterns` 축소 (공개 API인 `login`/`reissue`만 제외)
+- Service / Controller 테스트 코드 추가
+- `ErrorCode`에 필요 시 신규 코드 추가 (현재는 기존 `INVALID_INPUT_VALUE`, `DUPLICATED_NICKNAME` 활용)
+
+### 이번 PR에서 제외 (별도 이슈로 분리)
+- 닉네임 금지어(욕설) 필터링
+- 전역 에러 응답 포맷 변경 (RFC 7807 Problem Details 등)
+- `logout` / `withdraw` 동작 검증 (화이트리스트 변경으로 인한 부수 영향만 고려)
+
+---
+
+## 2. API 계약
+
+### 2-1. 닉네임 중복 확인
+
+```
+GET /api/auth/check-nickname?nickname={nickname}
+Authorization: Bearer {accessToken}
+```
+
+| 항목 | 값 |
+|------|----|
+| 인증 | 필요 (`@AuthMember LoginMember`) |
+| Query Parameter | `nickname` (String, required, 2~10자, `^[가-힣a-zA-Z0-9]+$`) |
+| 성공 응답 | `200 OK` `{"available": boolean}` |
+| 형식 오류 | `400 INVALID_INPUT_VALUE` |
+| 미인증 | `401 UNAUTHENTICATED_REQUEST` |
+
+**동작**: `MemberRepository.existsByNickname(nickname)` 결과의 **부정값**을 `available`로 반환한다. 본인이 사용 중인 닉네임도 `available: false`가 되며, 이는 프론트에서 "본인 닉네임 입력 시 중복확인 버튼 비활성화"로 이미 차단한다.
+
+### 2-2. 닉네임 변경
+
+```
+PATCH /api/auth/nickname
+Authorization: Bearer {accessToken}
+Content-Type: application/json
+
+{ "nickname": "..." }
+```
+
+| 항목 | 값 |
+|------|----|
+| 인증 | 필요 |
+| Request Body | `nickname` (String, required, 2~10자, `^[가-힣a-zA-Z0-9]+$`) |
+| 성공 응답 | `200 OK` `{"nickname": "..."}` |
+| 형식 오류 | `400 INVALID_INPUT_VALUE` |
+| 중복 | `409 DUPLICATED_NICKNAME` |
+| 미인증 | `401 UNAUTHENTICATED_REQUEST` |
+| 회원 없음 | `404 MEMBER_NOT_FOUND` (이론상, 유효 토큰+DB 삭제 동시 발생 시) |
+
+**동작**: 중복 체크 후 `Member.updateNickname()`로 갱신. JPA dirty checking으로 `UPDATE` 쿼리 발생. 토큰 재발급 없음.
+
+### 2-3. 닉네임 형식 규칙
+
+- 길이: **2~10자**
+- 허용 문자: 한글, 영문 대소문자, 숫자
+- 금지: 공백, 특수문자, 이모지
+- 정규식: `^[가-힣a-zA-Z0-9]+$` (+ `@Size(min=2, max=10)`)
+
+---
+
+## 3. 파일 구조
+
+```
+SS-Web/
+  src/main/java/com/elipair/spacestudyship/
+    config/WebConfig.java               [수정] 인터셉터 예외 경로 축소
+    controller/auth/AuthController.java [수정] 엔드포인트 2개 추가
+  src/test/java/com/elipair/spacestudyship/controller/auth/
+    AuthControllerTest.java             [신규] MockMvc 슬라이스
+
+SS-Auth/
+  src/main/java/com/elipair/spacestudyship/auth/
+    dto/CheckNicknameRequest.java       [신규] record + Bean Validation
+    dto/CheckNicknameResponse.java      [신규] record
+    dto/UpdateNicknameRequest.java      [신규] record + Bean Validation
+    dto/UpdateNicknameResponse.java     [신규] record
+    service/AuthService.java            [수정] 메서드 2개 추가
+  src/test/java/com/elipair/spacestudyship/auth/
+    service/AuthServiceTest.java        [신규] 신규 메서드 커버
+
+SS-Auth (변경 없음)
+  constant/SecurityUrls.java            이번 범위에서 변경 없음 (5장 참조)
+
+SS-Member/ (변경 없음)
+  entity/Member.java                    기존 updateNickname() 재사용
+  repository/MemberRepository.java      기존 existsByNickname() 재사용
+
+SS-Common/ (변경 없음)
+  exception/ErrorCode.java              기존 코드로 커버 가능
+  exception/GlobalExceptionHandler.java 기존 구조 그대로
+```
+
+### 판단 근거
+
+- **Controller는 기존 `AuthController`에 추가**: 스펙상 `/api/auth` 하위 경로이므로 같은 컨트롤러에 두는 것이 일관성 있음
+- **Service는 기존 `AuthService`에 추가**: 메서드가 2개뿐이고 Auth 도메인의 프로필 관련 기능. 프로필 도메인이 커지면 그때 `MemberProfileService`로 분리 (YAGNI)
+- **DTO는 `SS-Auth/dto/`에 배치**: 기존 `LoginRequest` 등과 동일 위치, CLAUDE.md의 "모듈별 dto/ 폴더" 규칙 준수
+- **Entity/Repository 수정 불필요**: `Member.updateNickname()`과 `MemberRepository.existsByNickname()`이 이미 존재
+
+### Flyway 마이그레이션
+
+**필요 없음.** Entity 스키마 변경이 없고 `members` 테이블의 `nickname` 컬럼은 이미 `unique` 제약이 걸려 있다.
+
+---
+
+## 4. 데이터 흐름
+
+### `GET /api/auth/check-nickname?nickname=...`
+
+```
+Request → AuthInterceptor (토큰 검증, request.loginMember 세팅)
+       → LoginMemberArgumentResolver (LoginMember 주입)
+       → AuthController.checkNickname(loginMember, @Valid nickname)
+           ↓ @Pattern/@Size 검증 실패 시 MethodArgumentNotValidException
+       → AuthService.checkNickname(nickname)
+           ↓ memberRepository.existsByNickname(nickname)
+       → CheckNicknameResponse(available = !exists)
+       → 200 OK
+```
+
+### `PATCH /api/auth/nickname`
+
+```
+Request → AuthInterceptor → LoginMemberArgumentResolver
+       → AuthController.updateNickname(loginMember, @Valid UpdateNicknameRequest)
+           ↓ 형식 검증 실패 → 400
+       → AuthService.updateNickname(loginMember.memberId(), request) [@Transactional]
+           1. existsByNickname(request.nickname())
+              → true면 throw CustomException(DUPLICATED_NICKNAME) [409]
+           2. getByMemberId(memberId)
+              → 없으면 throw CustomException(MEMBER_NOT_FOUND) [404]
+           3. member.updateNickname(request.nickname())  // dirty checking
+       → UpdateNicknameResponse(member.getNickname())
+       → 200 OK
+```
+
+### 예외 처리
+
+- Bean Validation 실패 → `GlobalExceptionHandler.handleValidationException`이 `400 INVALID_INPUT_VALUE`로 처리 (필드 에러 메시지 `detail`에 포함)
+- `CustomException` → `handleCustomException`이 해당 `ErrorCode`의 `HttpStatus`/`message`로 응답
+- 미인증 → `LoginMemberArgumentResolver`가 `UNAUTHENTICATED_REQUEST(401)` throw
+
+### 동시성 / 중복 방지
+
+- `PATCH` 요청에서 `existsByNickname` 체크 후 `update` 사이에 동일 닉네임으로 다른 트랜잭션이 `INSERT`/`UPDATE`할 경우 → **DB의 `nickname` unique 제약이 최종 방어선**
+- `@Transactional`로 원자성 확보. unique 제약 위반 시 `DataIntegrityViolationException`이 던져지며, 현재는 `Exception` 핸들러로 500 처리되지만 극히 드문 경합 상황이므로 이번 범위에서는 특별한 처리 없음 (별도 고도화 항목)
+
+---
+
+## 5. 인증 경로 정리
+
+### 아키텍처 이해 (중요)
+
+현재 프로젝트의 인증 구조:
+- **Spring Security** (`SecurityConfig`): `SecurityUrls.AUTH_WHITELIST`에 등록된 경로는 `permitAll`. `/api/auth/**`가 통째로 들어있어 이 계층에서는 JWT 검증을 하지 않는다.
+- **AuthInterceptor**: `WebConfig.addInterceptors`에서 `/api/**`에 등록되며, `excludePathPatterns` 외의 경로는 `Authorization: Bearer` 토큰을 검증하고 `loginMember` 속성을 세팅한다.
+
+즉, **실질적인 JWT 검증은 `AuthInterceptor`가 담당**한다. Spring Security의 `/api/auth/**` whitelist는 유지해야 한다 (빼면 JWT 처리 필터 부재로 정상 요청도 401이 됨).
+
+### 변경 범위: `WebConfig.addInterceptors.excludePathPatterns`만 조정
+
+#### Before
+
+```java
+.excludePathPatterns(
+        "/api/auth/**",  // AuthController 전체 제외
+        "/actuator/health"
+);
+```
+
+#### After
+
+```java
+.excludePathPatterns(
+        "/api/auth/login",
+        "/api/auth/reissue",
+        "/actuator/health"
+);
+```
+
+`SecurityUrls.AUTH_WHITELIST`는 이번 범위에서 **변경하지 않는다**. Spring Security 계층 전면 재설계(JWT Security Filter 도입 등)는 별도 이슈에서 다룬다.
+
+### 영향
+
+| API | 기존 동작 | 변경 후 |
+|-----|----------|---------|
+| `POST /api/auth/login` | 공개 | 공개 (유지) |
+| `POST /api/auth/reissue` | 공개 | 공개 (유지) |
+| `POST /api/auth/logout` | 공개 (스펙 위반) | 인증 필요 (AuthInterceptor가 검증) |
+| `DELETE /api/auth/withdraw` | 미구현 | 미구현 (영향 없음) |
+| `GET /api/auth/check-nickname` | 신규 | 인증 필요 |
+| `PATCH /api/auth/nickname` | 신규 | 인증 필요 |
+
+---
+
+## 6. 테스트 전략
+
+커버리지 목표: **80%+** (글로벌 `rules/testing.md` 준수)
+
+### 6-1. `AuthServiceTest` (단위 테스트, Mockito)
+
+**checkNickname**
+- `existsByNickname`이 `false` → `available=true` 반환
+- `existsByNickname`이 `true` → `available=false` 반환
+
+**updateNickname**
+- 사용 가능한 닉네임 입력 → `Member.updateNickname` 호출, `UpdateNicknameResponse` 반환
+- 이미 존재하는 닉네임 입력 → `CustomException(DUPLICATED_NICKNAME)` throw, 업데이트 호출 안 됨
+- `memberId`로 조회 실패 → `CustomException(MEMBER_NOT_FOUND)` throw
+
+### 6-2. `AuthControllerTest` (슬라이스 테스트, MockMvc)
+
+**GET /api/auth/check-nickname**
+- 정상 쿼리 + 인증 → 200, `$.available` 필드 검증
+- `nickname` 파라미터 누락 → 400
+- 1자 / 11자 / 특수문자 / 공백 포함 → 400
+- 인증 없음 → 401
+
+**PATCH /api/auth/nickname**
+- 정상 요청 + 인증 → 200, `$.nickname` 필드 검증
+- 본문 닉네임 형식 위반 → 400
+- 중복 닉네임 → 409 (`AuthService` mock이 예외 throw)
+- 인증 없음 → 401
+
+### 6-3. Mocking 방침
+
+- Service 테스트: `@ExtendWith(MockitoExtension.class)` + `@Mock MemberRepository`
+- Controller 테스트: `@WebMvcTest(AuthController.class)` + `AuthService` 모킹, `LoginMemberArgumentResolver` 모킹 또는 request attribute에 `loginMember` 직접 세팅으로 인증 주입
+- 모킹 어노테이션은 Spring Boot 4.x 환경에 맞게 `@MockitoBean` 계열 사용 (Spring Framework 6.2+ 표준)
+
+### 6-4. 통합 테스트
+
+이번 범위에서는 제외. 통합 테스트 인프라(`@SpringBootTest` + Testcontainers 또는 H2) 셋업은 별도 이슈에서 프로젝트 전반적으로 구축.
+
+---
+
+## 7. 구현 순서 (TDD)
+
+1. `SecurityUrls.AUTH_WHITELIST` 축소 + 기존 테스트 영향 확인
+2. DTO 3개 작성 (`CheckNicknameResponse`, `UpdateNicknameRequest`, `UpdateNicknameResponse`)
+3. `AuthServiceTest` 작성 (RED) → `AuthService` 메서드 2개 구현 (GREEN)
+4. `AuthControllerTest` 작성 (RED) → `AuthController` 엔드포인트 2개 구현 (GREEN)
+5. 빌드 및 테스트 통과 확인
+6. 필요 시 리팩터링
+
+---
+
+## 8. 수용 기준 (Acceptance Criteria)
+
+- [ ] `GET /api/auth/check-nickname` 엔드포인트가 스펙대로 동작
+- [ ] `PATCH /api/auth/nickname` 엔드포인트가 스펙대로 동작
+- [ ] 닉네임 형식 검증(길이, 허용 문자)이 요청 단계에서 동작
+- [ ] 중복 닉네임 요청 시 409 응답
+- [ ] 인증 없는 요청 시 401 응답
+- [ ] `/api/auth` 하위의 공개 API가 `login`, `reissue`로만 한정됨
+- [ ] 신규/수정된 코드에 대한 단위/슬라이스 테스트 통과
+- [ ] 전체 빌드 및 테스트 녹색


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 닉네임 중복 확인용 GET API 추가
  * 닉네임 변경용 PATCH API 추가
  * 닉네임 유효성 검사 적용(2~10자, 한글·영문·숫자)

* **동작 변경**
  * 인증 인터셉터 제외 경로를 축소해 일부 인증 관련 엔드포인트가 인터셉터의 보호를 받도록 변경

* **테스트**
  * 서비스 및 컨트롤러 단위/슬라이스 테스트 추가

* **문서화**
  * 닉네임 API 설계 및 구현 계획 문서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->